### PR TITLE
Add Tkinter GUI for Danish to Russian speech translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,36 @@ Finally run the client:
 
 Within the client, you can select the appropriate input and output device that audio will be piped through.
 
+### Desktop GUI (Danish → Russian)
+
+The repository also contains a lightweight Tkinter desktop application that wraps the
+existing realtime pipeline and runs everything locally (microphone → Whisper →
+machine translation → SpeechT5 TTS). The app lets you pick the microphone and
+Whisper model, shows intermediate transcripts, counts processed phrases and
+displays latency statistics.
+
+1. Create and activate a Python 3.11 environment (see the server installation instructions above).
+2. Install the project requirements:
+   ```bash
+   pip install -r server/requirements.txt
+   pip install -r client/requirements.txt
+   ```
+   Tkinter is bundled with standard Windows and macOS Python distributions. On
+   some Linux distributions you may need to install it separately (for example
+   `sudo apt-get install python3-tk`).
+3. Launch the GUI:
+   ```bash
+   python -m client.gui_app
+   ```
+4. In the window that opens:
+   - choose the input microphone from the drop-down list,
+   - select the Whisper model size (`base`, `small`, or `medium`),
+   - press **Start** to begin the Danish → Russian speech translation pipeline.
+5. Use the **Stop** button to end the session. The interface shows the latest
+   Danish transcription, the Russian translation, the “audible” microphone
+   indicator, phrase counter and average latency (time between the end of a
+   phrase and playback of the translated audio).
+
 ### Notebooks for Testing
 
 ## speech.ipynb

--- a/client/gui_app.py
+++ b/client/gui_app.py
@@ -1,0 +1,364 @@
+"""Tkinter based desktop application for the realtime translation pipeline."""
+from __future__ import annotations
+
+import queue
+import threading
+import tkinter as tk
+from tkinter import messagebox, scrolledtext, ttk
+from typing import Dict, Optional
+
+import sounddevice as sd
+
+from client.translator import Translator, TranslatorEvent
+
+
+class TranslatorGUI:
+    """User interface wrapper for the :class:`Translator` pipeline."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("Danish → Russian Speech Translator")
+        self.root.geometry("760x640")
+
+        self.event_queue: "queue.Queue[TranslatorEvent]" = queue.Queue()
+        self.translator: Optional[Translator] = None
+        self.active_model: Optional[str] = None
+
+        self.is_running = False
+
+        self.microphone_var = tk.StringVar()
+        self.model_var = tk.StringVar(value="base")
+        self.partial_var = tk.StringVar(value="")
+        self.status_var = tk.StringVar(value="Готов к запуску")
+        self.phrase_count_var = tk.StringVar(value="0")
+        self.latest_latency_var = tk.StringVar(value="—")
+        self.average_latency_var = tk.StringVar(value="—")
+        self.audible_var = tk.StringVar(value="Не слышно")
+
+        self.volume_level = tk.DoubleVar(value=0.0)
+
+        self._build_ui()
+        self._populate_microphones()
+
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+        self.root.after(100, self._process_events)
+
+    # ------------------------------------------------------------------
+    # UI creation helpers
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        top_frame = ttk.Frame(self.root, padding=10)
+        top_frame.pack(fill=tk.X)
+
+        mic_label = ttk.Label(top_frame, text="Микрофон:")
+        mic_label.grid(row=0, column=0, sticky=tk.W, padx=(0, 8))
+
+        self.microphone_combo = ttk.Combobox(
+            top_frame, textvariable=self.microphone_var, state="readonly", width=50
+        )
+        self.microphone_combo.grid(row=0, column=1, sticky=tk.W)
+
+        refresh_button = ttk.Button(
+            top_frame, text="Обновить", command=self._populate_microphones
+        )
+        refresh_button.grid(row=0, column=2, padx=(8, 0))
+
+        model_label = ttk.Label(top_frame, text="Модель Whisper:")
+        model_label.grid(row=1, column=0, sticky=tk.W, pady=(8, 0))
+
+        model_combo = ttk.Combobox(
+            top_frame,
+            textvariable=self.model_var,
+            state="readonly",
+            values=["base", "small", "medium"],
+        )
+        model_combo.grid(row=1, column=1, sticky=tk.W, pady=(8, 0))
+
+        button_frame = ttk.Frame(self.root, padding=(10, 0, 10, 10))
+        button_frame.pack(fill=tk.X)
+
+        self.start_button = ttk.Button(
+            button_frame, text="Start", command=self.start_translation
+        )
+        self.start_button.grid(row=0, column=0, padx=(0, 10))
+
+        self.stop_button = ttk.Button(
+            button_frame, text="Stop", command=self.stop_translation, state=tk.DISABLED
+        )
+        self.stop_button.grid(row=0, column=1)
+
+        status_frame = ttk.LabelFrame(self.root, text="Статус", padding=10)
+        status_frame.pack(fill=tk.X, padx=10, pady=(0, 10))
+
+        ttk.Label(status_frame, textvariable=self.status_var).grid(
+            row=0, column=0, columnspan=2, sticky=tk.W
+        )
+
+        ttk.Label(status_frame, text="Громкость микрофона:").grid(
+            row=1, column=0, sticky=tk.W, pady=(8, 0)
+        )
+        self.volume_bar = ttk.Progressbar(
+            status_frame, orient=tk.HORIZONTAL, maximum=1.0, variable=self.volume_level
+        )
+        self.volume_bar.grid(row=1, column=1, sticky=(tk.W, tk.E), pady=(8, 0))
+
+        self.audible_label = ttk.Label(status_frame, textvariable=self.audible_var)
+        self.audible_label.grid(row=1, column=2, padx=(12, 0), sticky=tk.W)
+
+        ttk.Label(status_frame, text="Обработано фраз:").grid(
+            row=2, column=0, sticky=tk.W, pady=(8, 0)
+        )
+        ttk.Label(status_frame, textvariable=self.phrase_count_var).grid(
+            row=2, column=1, sticky=tk.W, pady=(8, 0)
+        )
+
+        ttk.Label(status_frame, text="Последняя задержка, мс:").grid(
+            row=3, column=0, sticky=tk.W, pady=(8, 0)
+        )
+        ttk.Label(status_frame, textvariable=self.latest_latency_var).grid(
+            row=3, column=1, sticky=tk.W, pady=(8, 0)
+        )
+
+        ttk.Label(status_frame, text="Средняя задержка, мс:").grid(
+            row=4, column=0, sticky=tk.W, pady=(8, 0)
+        )
+        ttk.Label(status_frame, textvariable=self.average_latency_var).grid(
+            row=4, column=1, sticky=tk.W, pady=(8, 0)
+        )
+
+        transcription_frame = ttk.Frame(self.root, padding=10)
+        transcription_frame.pack(fill=tk.BOTH, expand=True)
+
+        left_frame = ttk.LabelFrame(
+            transcription_frame, text="Распознанный датский текст", padding=8
+        )
+        left_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(0, 5))
+
+        self.danish_text = scrolledtext.ScrolledText(
+            left_frame, wrap=tk.WORD, height=12, state=tk.DISABLED
+        )
+        self.danish_text.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(left_frame, textvariable=self.partial_var, foreground="#444").pack(
+            anchor=tk.W, pady=(6, 0)
+        )
+
+        right_frame = ttk.LabelFrame(
+            transcription_frame, text="Русский перевод", padding=8
+        )
+        right_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(5, 0))
+
+        self.russian_text = scrolledtext.ScrolledText(
+            right_frame, wrap=tk.WORD, height=12, state=tk.DISABLED
+        )
+        self.russian_text.pack(fill=tk.BOTH, expand=True)
+
+    def _populate_microphones(self) -> None:
+        devices = sd.query_devices()
+        microphones = []
+        default_input_index = sd.default.device[0]
+        for index, device in enumerate(devices):
+            if device.get("max_input_channels", 0) > 0:
+                label = f"{index}: {device['name']}"
+                microphones.append((label, index))
+
+        if not microphones:
+            self.microphone_combo["values"] = []
+            self.microphone_var.set("")
+            messagebox.showerror(
+                "Нет устройств",
+                "Не найдено ни одного входного аудиоустройства. Подключите микрофон и нажмите 'Обновить'.",
+            )
+            return
+
+        labels = [item[0] for item in microphones]
+        self.microphone_mapping: Dict[str, int] = {label: idx for label, idx in microphones}
+        self.microphone_combo["values"] = labels
+
+        default_label = next(
+            (label for label, idx in microphones if idx == default_input_index),
+            microphones[0][0],
+        )
+        self.microphone_var.set(default_label)
+
+    # ------------------------------------------------------------------
+    # Control handlers
+    # ------------------------------------------------------------------
+    def start_translation(self) -> None:
+        if self.is_running:
+            return
+
+        selected_label = self.microphone_var.get()
+        if not selected_label:
+            messagebox.showwarning("Микрофон", "Выберите входное устройство.")
+            return
+
+        input_index = self.microphone_mapping[selected_label]
+        model_name = self.model_var.get()
+
+        self.status_var.set("Загрузка моделей...")
+        self.start_button.config(state=tk.DISABLED)
+        self.stop_button.config(state=tk.DISABLED)
+
+        if self.translator and self.active_model == model_name:
+            self.translator.input_device_index = input_index
+            thread = threading.Thread(
+                target=self._start_existing_translator, daemon=True
+            )
+            thread.start()
+        else:
+            thread = threading.Thread(
+                target=self._create_and_start_translator,
+                args=(input_index, model_name),
+                daemon=True,
+            )
+            thread.start()
+
+    def _start_existing_translator(self) -> None:
+        if not self.translator:
+            return
+        try:
+            self.translator.start()
+        except Exception as exc:  # pragma: no cover - defensive
+            self.event_queue.put(
+                TranslatorEvent("error", {"message": str(exc)})
+            )
+            self.event_queue.put(
+                TranslatorEvent("status", {"state": "stopped"})
+            )
+
+    def _create_and_start_translator(self, input_index: int, model_name: str) -> None:
+        try:
+            translator = Translator(
+                event_queue=self.event_queue,
+                input_device_index=input_index,
+                whisper_model=model_name,
+            )
+            self.translator = translator
+            self.active_model = model_name
+            translator.start()
+        except Exception as exc:  # pragma: no cover - defensive
+            self.event_queue.put(
+                TranslatorEvent("error", {"message": str(exc)})
+            )
+            self.event_queue.put(
+                TranslatorEvent("status", {"state": "stopped"})
+            )
+
+    def stop_translation(self) -> None:
+        if not self.translator:
+            return
+
+        self.stop_button.config(state=tk.DISABLED)
+
+        thread = threading.Thread(target=self._stop_translator, daemon=True)
+        thread.start()
+
+    def _stop_translator(self) -> None:
+        try:
+            if self.translator:
+                self.translator.stop()
+        except Exception as exc:  # pragma: no cover - defensive
+            self.event_queue.put(
+                TranslatorEvent("error", {"message": str(exc)})
+            )
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+    def _process_events(self) -> None:
+        try:
+            while True:
+                event = self.event_queue.get_nowait()
+                self._handle_event(event)
+        except queue.Empty:
+            pass
+        finally:
+            self.root.after(100, self._process_events)
+
+    def _handle_event(self, event: TranslatorEvent) -> None:
+        if event.type == "status":
+            self._handle_status(event.payload)
+        elif event.type == "warning":
+            self.status_var.set(event.payload.get("message", "Предупреждение"))
+        elif event.type == "error":
+            message = event.payload.get("message", "Произошла ошибка")
+            self.status_var.set(message)
+            messagebox.showerror("Ошибка", message)
+            self._set_running(False)
+        elif event.type == "volume":
+            self._update_volume(event.payload)
+        elif event.type == "partial_transcription":
+            self.partial_var.set(f"Идёт распознавание: {event.payload['text']}")
+        elif event.type == "final_transcription":
+            self._append_text(self.danish_text, event.payload["text"])
+            self.partial_var.set("")
+            self.phrase_count_var.set(str(event.payload.get("count", 0)))
+        elif event.type == "translation":
+            self._append_text(self.russian_text, event.payload["text"])
+        elif event.type == "latency":
+            latest = event.payload.get("latest")
+            average = event.payload.get("average")
+            if latest is not None:
+                self.latest_latency_var.set(f"{latest * 1000:.0f}")
+            if average is not None:
+                self.average_latency_var.set(f"{average * 1000:.0f}")
+
+    def _handle_status(self, payload: Dict) -> None:
+        state = payload.get("state")
+        if state == "starting":
+            self.status_var.set("Запуск...")
+            self._set_running(True, buttons=False)
+        elif state == "running":
+            self.status_var.set("Работает")
+            self._set_running(True)
+        elif state == "stopped":
+            self.status_var.set("Остановлено")
+            self._set_running(False)
+            self.partial_var.set("")
+            self.latest_latency_var.set("—")
+            self.average_latency_var.set("—")
+            self.volume_level.set(0.0)
+            self.audible_var.set("Не слышно")
+
+    def _set_running(self, running: bool, buttons: bool = True) -> None:
+        self.is_running = running
+        if buttons:
+            self.start_button.config(state=tk.DISABLED if running else tk.NORMAL)
+            self.stop_button.config(state=tk.NORMAL if running else tk.DISABLED)
+
+    def _update_volume(self, payload: Dict) -> None:
+        volume = min(max(payload.get("value", 0.0), 0.0), 1.0)
+        audible = payload.get("audible", False)
+        self.volume_level.set(volume)
+        if audible:
+            self.audible_var.set("Слышно")
+            self.audible_label.configure(foreground="green")
+        else:
+            self.audible_var.set("Не слышно")
+            self.audible_label.configure(foreground="red")
+
+    def _append_text(self, widget: scrolledtext.ScrolledText, text: str) -> None:
+        widget.configure(state=tk.NORMAL)
+        widget.insert(tk.END, text + "\n")
+        widget.see(tk.END)
+        widget.configure(state=tk.DISABLED)
+
+    def on_close(self) -> None:
+        if self.translator:
+            try:
+                self.translator.stop()
+            except Exception:
+                pass
+        self.root.destroy()
+
+
+def main() -> None:
+    root = tk.Tk()
+    TranslatorGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/client/translator.py
+++ b/client/translator.py
@@ -1,0 +1,356 @@
+"""Translator module that wraps the existing speech pipeline for GUI usage."""
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+import sounddevice as sd
+import torch
+from transformers import MarianMTModel, MarianTokenizer
+
+from server.models.speech_recognition import SpeechRecognitionModel
+from server.models.text_to_speech import TextToSpeechModel
+
+from client.utils.print_audio import get_volume_norm
+
+
+@dataclass
+class TranslatorEvent:
+    """Data structure representing events sent from :class:`Translator`."""
+
+    type: str
+    payload: dict
+
+
+class Translator:
+    """High level wrapper around the existing realtime translation pipeline.
+
+    The class manages microphone input, Whisper transcription, neural machine
+    translation and Text-to-Speech playback. Updates are emitted through a
+    thread-safe queue that the GUI can poll.
+    """
+
+    SAMPLE_RATE = 16_000
+    SAMPLE_WIDTH = 2  # Bytes for int16 samples
+
+    def __init__(
+        self,
+        event_queue: "queue.Queue[TranslatorEvent]",
+        input_device_index: Optional[int] = None,
+        output_device_index: Optional[int] = None,
+        whisper_model: str = "base",
+        source_lang: str = "da",
+        target_lang: str = "ru",
+        translation_model_name: str = "Helsinki-NLP/opus-mt-da-ru",
+    ) -> None:
+        self.event_queue = event_queue
+        self.input_device_index = input_device_index
+        # sounddevice uses a tuple of (input, output). If an explicit output
+        # device is not provided we fall back to the default from sounddevice.
+        if output_device_index is None:
+            default_devices = sd.default.device
+            self.output_device_index = default_devices[1]
+        else:
+            self.output_device_index = output_device_index
+
+        self.source_lang = source_lang
+        self.target_lang = target_lang
+
+        self.data_queue: "queue.Queue[tuple[object, bytes]]" = queue.Queue()
+        self.transcriber = SpeechRecognitionModel(
+            data_queue=self.data_queue,
+            generation_callback=self._handle_generation,
+            final_callback=self._handle_final_transcription,
+            model_name=whisper_model,
+        )
+        # Force Whisper to transcribe in the source language instead of
+        # translating to English directly so that we can display the original
+        # transcript to the user.
+        self.transcriber.decoding_options = {
+            "task": "transcribe",
+            "language": self.source_lang,
+        }
+
+        self.text_to_speech = TextToSpeechModel(
+            callback_function=self._handle_synthesised_audio
+        )
+        self.text_to_speech.load_speaker_embeddings()
+
+        self.translation_tokenizer = MarianTokenizer.from_pretrained(
+            translation_model_name
+        )
+        self.translation_model = MarianMTModel.from_pretrained(
+            translation_model_name
+        )
+
+        self._stop_event = threading.Event()
+        self._audio_stream: Optional[sd.InputStream] = None
+        self._playback_thread: Optional[threading.Thread] = None
+        self._client_token = object()
+        self._playback_queue: "queue.Queue[Optional[Tuple[np.ndarray, Optional[float]]]]" = queue.Queue()
+        self._latency_times: "queue.Queue[float]" = queue.Queue()
+
+        self._running = False
+        self._latest_volume = 0.0
+        self._last_volume_event = 0.0
+        self._volume_threshold = 0.01
+
+        self._phrase_count = 0
+        self._total_latency = 0.0
+
+        # sounddevice callbacks operate in separate threads. We cache a token so
+        # that SpeechRecognitionModel treats all audio chunks as coming from the
+        # same "client".
+        self._client_identifier = object()
+
+    def start(self) -> None:
+        """Start processing audio and translation."""
+
+        if self._running:
+            return
+
+        self._running = True
+        self._stop_event.clear()
+
+        self.event_queue.put(
+            TranslatorEvent("status", {"state": "starting"})
+        )
+
+        # Reset statistics
+        self._phrase_count = 0
+        self._total_latency = 0.0
+
+        while not self.data_queue.empty():
+            try:
+                self.data_queue.get_nowait()
+            except queue.Empty:  # pragma: no cover - defensive
+                break
+
+        self.transcriber.start(self.SAMPLE_RATE, self.SAMPLE_WIDTH)
+
+        self._audio_stream = sd.InputStream(
+            samplerate=self.SAMPLE_RATE,
+            channels=1,
+            dtype="float32",
+            device=self.input_device_index,
+            callback=self._audio_callback,
+        )
+        self._audio_stream.start()
+
+        self._playback_thread = threading.Thread(
+            target=self._playback_worker, daemon=True
+        )
+        self._playback_thread.start()
+
+        self.event_queue.put(
+            TranslatorEvent("status", {"state": "running"})
+        )
+
+    def stop(self) -> None:
+        """Stop all background processing."""
+
+        if not self._running:
+            return
+
+        self._running = False
+        self._stop_event.set()
+
+        if self._audio_stream is not None:
+            self._audio_stream.stop()
+            self._audio_stream.close()
+            self._audio_stream = None
+
+        sd.stop()
+
+        self.transcriber.stop()
+
+        # Drain latency information
+        while not self._latency_times.empty():
+            try:
+                self._latency_times.get_nowait()
+            except queue.Empty:  # pragma: no cover - defensive
+                break
+
+        # Drain playback queue and notify worker to exit
+        self._playback_queue.put(None)
+        if self._playback_thread is not None:
+            self._playback_thread.join()
+            self._playback_thread = None
+
+        self.event_queue.put(
+            TranslatorEvent("status", {"state": "stopped"})
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helper methods
+    # ------------------------------------------------------------------
+    def _audio_callback(self, indata, frames, time_info, status) -> None:
+        if not self._running:
+            return
+
+        if status:
+            self.event_queue.put(
+                TranslatorEvent("warning", {"message": str(status)})
+            )
+
+        volume = float(get_volume_norm(indata))
+        previous_volume = self._latest_volume
+        self._latest_volume = volume
+        current_time = time.time()
+        if (
+            current_time - self._last_volume_event > 0.2
+            or abs(volume - previous_volume) > 0.05
+        ):
+            self._last_volume_event = current_time
+            self.event_queue.put(
+                TranslatorEvent(
+                    "volume",
+                    {
+                        "value": volume,
+                        "audible": volume > self._volume_threshold,
+                    },
+                )
+            )
+
+        audio_int16 = np.clip(indata, -1.0, 1.0)
+        audio_int16 = (audio_int16 * np.iinfo(np.int16).max).astype(np.int16)
+        self.data_queue.put((self._client_identifier, audio_int16.tobytes()))
+
+    def _handle_generation(self, packet: dict) -> None:
+        if not self._running:
+            return
+
+        text = packet.get("text", "").strip()
+        if not text:
+            return
+
+        self.event_queue.put(
+            TranslatorEvent("partial_transcription", {"text": text})
+        )
+
+    def _handle_final_transcription(self, text: str, _client_socket) -> None:
+        if not self._running:
+            return
+
+        text = (text or "").strip()
+        if not text:
+            return
+
+        self._phrase_count += 1
+        phrase_time = time.time()
+        self._latency_times.put(phrase_time)
+
+        self.event_queue.put(
+            TranslatorEvent(
+                "final_transcription",
+                {"text": text, "count": self._phrase_count},
+            )
+        )
+
+        try:
+            translation = self._translate_text(text)
+        except Exception as exc:  # pragma: no cover - defensive
+            self._discard_pending_latency()
+            self.event_queue.put(
+                TranslatorEvent(
+                    "error",
+                    {
+                        "message": f"Translation error: {exc}",
+                    },
+                )
+            )
+            return
+
+        if translation:
+            self.event_queue.put(
+                TranslatorEvent(
+                    "translation", {"text": translation, "language": self.target_lang}
+                )
+            )
+            self.text_to_speech.synthesise(translation, self._client_token)
+        else:
+            self._discard_pending_latency()
+
+    def _translate_text(self, text: str) -> str:
+        inputs = self.translation_tokenizer(
+            text, return_tensors="pt", padding=True
+        )
+        with torch.no_grad():
+            generated_tokens = self.translation_model.generate(**inputs)
+        return self.translation_tokenizer.decode(
+            generated_tokens[0], skip_special_tokens=True
+        )
+
+    def _handle_synthesised_audio(self, audio_tensor: torch.Tensor, _client_socket) -> None:
+        if not self._running:
+            return
+
+        audio = audio_tensor.detach().cpu().numpy().astype(np.float32)
+        phrase_time = None
+        try:
+            phrase_time = self._latency_times.get_nowait()
+        except queue.Empty:
+            pass
+
+        self._playback_queue.put((audio, phrase_time))
+
+    def _playback_worker(self) -> None:
+        while True:
+            try:
+                item = self._playback_queue.get(timeout=0.1)
+            except queue.Empty:
+                if self._stop_event.is_set():
+                    break
+                continue
+
+            if item is None:
+                self._playback_queue.task_done()
+                break
+
+            audio, phrase_time = item
+            if not self._running:
+                self._playback_queue.task_done()
+                continue
+            try:
+                playback_start = time.time()
+                sd.play(
+                    audio,
+                    samplerate=self.SAMPLE_RATE,
+                    device=self.output_device_index,
+                    blocking=True,
+                )
+                sd.wait()
+                if phrase_time is not None and self._phrase_count > 0:
+                    latency = playback_start - phrase_time
+                    self._total_latency += latency
+                    average_latency = self._total_latency / max(
+                        self._phrase_count, 1
+                    )
+                    self.event_queue.put(
+                        TranslatorEvent(
+                            "latency",
+                            {
+                                "latest": latency,
+                                "average": average_latency,
+                            },
+                        )
+                    )
+            except Exception as exc:  # pragma: no cover - defensive
+                self.event_queue.put(
+                    TranslatorEvent(
+                        "error", {"message": f"Playback error: {exc}"}
+                    )
+                )
+            finally:
+                self._playback_queue.task_done()
+
+    def _discard_pending_latency(self) -> None:
+        try:
+            self._latency_times.get_nowait()
+        except queue.Empty:
+            pass
+


### PR DESCRIPTION
## Summary
- add a reusable Translator class that wires the existing Whisper, MarianMT and SpeechT5 components together for Danish to Russian speech translation with latency tracking
- build a Tkinter-based desktop GUI to select microphones/models, display transcripts, show translation metrics and control the pipeline
- document GUI installation and usage instructions in the README

## Testing
- python -m compileall client/gui_app.py client/translator.py

------
https://chatgpt.com/codex/tasks/task_e_68cecc485b34832588f64f77333a179c